### PR TITLE
プラグインの依存関係に記述すべきものを書いた

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -2,7 +2,9 @@
 slug: :worldon
 depends:
   mikutter: 3.6.1
-  plugin: []
+  plugin:
+    - world
+    - spell
 version: '1.0'
 author: 
 name: Worldon


### PR DESCRIPTION
プラグインを可能な限り取り除いたうんこでたデーモンにこのプラグインを指定したら、依存関係が足りてなかったので追記しました。