### PR TITLE
World Modelのmodel slugをPlugin slugと同じものにした #15

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Plugin::Worldon
   class AccountSource < Diva::Model
     #register :worldon_account_source, name: "Mastodonアカウント追加情報(Worldon)"
@@ -74,7 +75,11 @@ module Plugin::Worldon
     end
 
     def icon
-      Plugin.filtering(:photo_filter, avatar_static, [])[1].first
+      Enumerator.new{|y|
+        Plugin.filtering(:photo_filter, avatar_static, y)
+      }.lazy.map{|photo|
+        Plugin.filtering(:miracle_icon_filter, photo)[0]
+      }.first
     end
   end
 end

--- a/model/world.rb
+++ b/model/world.rb
@@ -1,6 +1,7 @@
+# coding: utf-8
 module Plugin::Worldon
   class World < Diva::Model
-    register :worldon_for_mastodon, name: "Mastodonアカウント(Worldon)"
+    register :worldon, name: "Mastodonアカウント(Worldon)"
 
     field.string :id, required: true
     field.string :slug, required: true

--- a/spell.rb
+++ b/spell.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 class Gtk::PostBox
   def worldon_get_reply_to
     @to&.first
@@ -10,7 +11,7 @@ Plugin.create(:worldon) do
   # command
   custom_postable = Proc.new do |opt|
     world, = Plugin.filtering(:world_current, nil)
-    world.class.slug == :worldon_for_mastodon && opt.widget.editable?
+    world.class.slug == :worldon && opt.widget.editable?
   end
 
   def visibility2select(s)
@@ -116,7 +117,7 @@ Plugin.create(:worldon) do
   # spell系
 
   # 投稿
-  defspell(:compose, :worldon_for_mastodon, condition: -> (world) { true }) do |world, body:, **opts|
+  defspell(:compose, :worldon, condition: -> (world) { true }) do |world, body:, **opts|
     if opts[:visibility].nil?
       opts.delete :visibility
     else
@@ -136,7 +137,7 @@ Plugin.create(:worldon) do
     end
   end
 
-  defspell(:compose, :worldon_for_mastodon, :worldon_status, condition: -> (world, status) { true }) do |world, status, body:, **opts|
+  defspell(:compose, :worldon, :worldon_status, condition: -> (world, status) { true }) do |world, status, body:, **opts|
     if opts[:visibility].nil?
       opts.delete :visibility
     else
@@ -185,13 +186,13 @@ Plugin.create(:worldon) do
     }
   end
 
-  defspell(:favorite, :worldon_for_mastodon, :worldon_status,
+  defspell(:favorite, :worldon, :worldon_status,
            condition: -> (world, status) { !status.actual_status.favorite? } # TODO: favorite?の引数にworldを取って正しく判定できるようにする
           ) do |world, status|
     Plugin.call(:worldon_favorite, world, status.actual_status)
   end
 
-  defspell(:favorited, :worldon_for_mastodon, :worldon_status,
+  defspell(:favorited, :worldon, :worldon_status,
            condition: -> (world, status) { status.actual_status.favorite? } # TODO: worldを使って正しく判定する
           ) do |world, status|
     Delayer::Deferred.new.next {
@@ -212,13 +213,13 @@ Plugin.create(:worldon) do
     }
   end
 
-  defspell(:share, :worldon_for_mastodon, :worldon_status,
+  defspell(:share, :worldon, :worldon_status,
            condition: -> (world, status) { status.rebloggable? } # TODO: rebloggable?の引数にworldを取って正しく判定できるようにする
           ) do |world, status|
     world.reblog status
   end
 
-  defspell(:shared, :worldon_for_mastodon, :worldon_status,
+  defspell(:shared, :worldon, :worldon_status,
            condition: -> (world, status) { status.actual_status.shared? } # TODO: worldを使って正しく判定する
           ) do |world, status|
     Delayer::Deferred.new.next {

--- a/worldon.rb
+++ b/worldon.rb
@@ -51,7 +51,7 @@ Plugin.create(:worldon) do
     [Enumerator.new{|y|
       Plugin.filtering(:worlds, y)
     }.select{|world|
-      world.class.slug == :worldon_for_mastodon
+      world.class.slug == :worldon
     }.to_a]
   end
 
@@ -60,7 +60,7 @@ Plugin.create(:worldon) do
   # world_currentがworldonならそれを、そうでなければ適当に探す。
   filter_worldon_current do
     world, = Plugin.filtering(:world_current, nil)
-    if world.class.slug != :worldon_for_mastodon
+    if world.class.slug != :worldon
       worlds, = Plugin.filter(:worldon_worlds, nil)
       world = worlds.first
     end
@@ -116,7 +116,7 @@ Plugin.create(:worldon) do
 
   # world追加
   on_world_create do |world|
-    if world.class.slug == :worldon_for_mastodon
+    if world.class.slug == :worldon
       Delayer.new {
         Plugin.call(:worldon_create_or_update_instance, world.domain, true)
         Plugin.call(:worldon_init_auth_stream, world)
@@ -126,7 +126,7 @@ Plugin.create(:worldon) do
 
   # world削除
   on_world_destroy do |world|
-    if world.class.slug == :worldon_for_mastodon
+    if world.class.slug == :worldon
       Delayer.new {
         worlds = Plugin.filtering(:worldon_worlds, nil).first
         # 他のworldで使わなくなったものは削除してしまう。


### PR DESCRIPTION
mikutter Redmine( https://dev.mikutter.hachune.net/issues/1175 )で報告してもらったバグを修正していて気づいた、関連する別の不具合の修正です。

issue #15 の問題の修正となります。

Mastodonで話していた時には、特定条件下ではこれをmergeするとWorldonのアカウント登録がリセットされる可能性があると書きましたが、mikutterのパッチに関わらず、このpull-reqをmergeするとアカウント登録が消えるので、再度登録する必要が出てきます。