### PR TITLE
絵文字表示するScoreの別の実装

### DIFF
--- a/model/emoji.rb
+++ b/model/emoji.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Plugin::Worldon
   # https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#emoji
   class Emoji < Diva::Model
@@ -6,5 +7,17 @@ module Plugin::Worldon
     field.string :shortcode, required: true
     field.uri :static_url, required: true
     field.uri :url, required: true
+
+    def description
+      ":#{shortcode}:"
+    end
+
+    memoize def inline_photo
+      Enumerator.new{|y| Plugin.filtering(:photo_filter, perma_link, y) }.first
+    end
+
+    def perma_link
+      static_url
+    end
   end
 end


### PR DESCRIPTION
正規表現によるマッチと複雑なindexの操作が大変だったので、含まれている可能性のある全ての絵文字に関して探索して、Emoji Modelを挿入していくようにしました。
Emoji Noteを作る処理をScoreの処理部分に書くと乱雑になるため、Emoji ModelがEmoji Noteとして機能するようにメソッドを定義しています。
また、ショートコードと絵文字をキーと値に取る `@emoji_h` は利用しなくなったため削除しました。

（結局行数としてはほとんど変わらなくて悲しい）