### PR TITLE
Emoji ModelのURIを、画像URLとは異なるものにする

### DIFF
--- a/model/emoji.rb
+++ b/model/emoji.rb
@@ -13,11 +13,11 @@ module Plugin::Worldon
     end
 
     memoize def inline_photo
-      Enumerator.new{|y| Plugin.filtering(:photo_filter, perma_link, y) }.first
+      Enumerator.new{|y| Plugin.filtering(:photo_filter, static_url, y) }.first
     end
 
-    def perma_link
-      static_url
+    def path
+      "/#{static_url.host}/#{shortcode}"
     end
 
     def inspect


### PR DESCRIPTION
以前pull-req送ったものに対する追加の修正です。
Emoji Modelはそれ自体を画像として扱えないのに、そのURIとして画像のURLを使ってしまっていました。

レンダラが絵文字画像を描画する時に使うPhoto Modelは Plugin::Worldon::Emoji#inline_photo メソッドで返しているため、表示への悪影響はありません。subparts-imageいじってる時に画像のURLになっているとどうしても添付画像として表示されてしまうという問題が発生していました。