### PR TITLE
Accountの:nameに:display_nameの中身を入れる

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -75,6 +75,8 @@ module Plugin::Worldon
       # activity対策
       hash[:idname] = hash[:acct]
 
+      hash[:name] = hash[:display_name]
+
       super hash
 
       @@account_storage[hash[:acct]] = self


### PR DESCRIPTION
mikutterのlibnotifyプラグインで:nameを参照していたので、通知のときに必要でした。