### PR TITLE
トゥートのageに対応

### DIFF
--- a/model/status.rb
+++ b/model/status.rb
@@ -615,5 +615,18 @@ module Plugin::Worldon
       @emoji_score[text] = score
     end
 
+    # 最終更新日時を取得する
+    def modified
+      @value[:modified] ||= [created, *(@retweets || []).map{ |x| x.modified }].compact.max
+    end
+    # 最終更新日時を更新する
+    def set_modified(time)
+      if modified < time
+        self[:modified] = time
+        Plugin::call(:message_modified, self)
+      end
+      self
+    end
+
   end
 end

--- a/model/status.rb
+++ b/model/status.rb
@@ -18,6 +18,7 @@ module Plugin::Worldon
     field.has :reblog, Status
     field.string :content, required: true
     field.time :created_at, required: true
+    field.time :modified
     field.time :created
     field.int :reblogs_count
     field.int :favourites_count
@@ -166,6 +167,7 @@ module Plugin::Worldon
       hash[:created_at] = Time.parse(hash[:created_at]).localtime
       # cairo_sub_parts_message_base用
       hash[:created] = hash[:created_at]
+      hash[:modified] = hash[:created_at]
 
       # mikutterはuriをURI型であるとみなす
       hash[:original_uri] = hash[:uri]

--- a/model/status.rb
+++ b/model/status.rb
@@ -110,9 +110,12 @@ module Plugin::Worldon
         else
           boost_uri = boost_record[:uri] # reblogには:urlが無いので:uriで入れておく
           boost = merge_or_create(domain_name, boost_uri, boost_record)
-
           status.reblog_status_uris << { uri: boost_uri, acct: boost_record[:account][:acct] }
           status.reblog_status_uris.uniq!
+
+          # ageなどの対応
+          world, = Plugin.filtering(:world_current, nil)
+          status.set_modified(boost.modified) if world and world.class.slug == :worldon and UserConfig[:retweeted_by_anyone_age] and ((UserConfig[:retweeted_by_myself_age] or world.user_obj != boost.user))
 
           boost[:retweet] = boost.reblog = status
             # わかりづらいが「ブーストした」statusの'reblog'プロパティにブースト元のstatusを入れている

--- a/sse_stream.rb
+++ b/sse_stream.rb
@@ -286,6 +286,7 @@ Plugin.create(:worldon) do
       status = pm::Status.build(domain, [payload[:status]]).first
       status.favorite_accts << user.acct
       world = status.from_me_world
+      status.set_modified(Time.now.localtime) if UserConfig[:favorited_by_anyone_age] and (UserConfig[:favorited_by_myself_age] or world.user_obj != user)
       if user && status && world
         Plugin.call(:favorite, world, user, status)
       end


### PR DESCRIPTION
抽出タブの並び順で「投稿時間（ふぁぼやリツイートでageる）」を選んだときにWorldonでもそのような動作になるようTwitter Worldからいい感じに移植してみました。

しばらく動かしてみた感じ、動いたり動かなかったりしているようで完全ではないかもしれませんが、ブーストしてからコメントするようなタイプのTLで流れがわからないみたいな問題は解消できています。